### PR TITLE
fix: clean up routes after merge conflict

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -14,19 +14,5 @@
 |
 */
 
-// Version 1 - Current stable version
-ApiRoute::version('v1', function () {
-    // Public routes with auth rate limiter (5/min - brute force protection)
-    Route::middleware('throttle:auth')->group(function () {
-        Route::post('register', [AuthController::class, 'register'])->name('api.v1.register');
-        Route::post('login', [AuthController::class, 'login'])->name('api.v1.login');
-    });
-
-    // Protected routes with authenticated rate limiter (120/min)
-    Route::middleware(['auth:sanctum', 'throttle:authenticated'])->group(function () {
-        Route::post('logout', [AuthController::class, 'logout'])->name('api.v1.logout');
-        Route::get('me', [AuthController::class, 'me'])->name('api.v1.me');
-    });
-})
-    ->current()
-    ->rateLimit(60); // Global rate limit: 60 requests/minute for v1
+// Routes are now loaded automatically from config/apiroute.php
+// See routes/api/v1.php for version 1 routes

--- a/routes/api/v1.php
+++ b/routes/api/v1.php
@@ -12,12 +12,14 @@ use Illuminate\Support\Facades\Route;
 |
 */
 
-// Public routes
-Route::post('register', [AuthController::class, 'register'])->name('api.v1.register');
-Route::post('login', [AuthController::class, 'login'])->name('api.v1.login');
+// Public routes with auth rate limiter (5/min - brute force protection)
+Route::middleware('throttle:auth')->group(function () {
+    Route::post('register', [AuthController::class, 'register'])->name('api.v1.register');
+    Route::post('login', [AuthController::class, 'login'])->name('api.v1.login');
+});
 
-// Protected routes
-Route::middleware('auth:sanctum')->group(function () {
+// Protected routes with authenticated rate limiter (120/min)
+Route::middleware(['auth:sanctum', 'throttle:authenticated'])->group(function () {
     Route::post('logout', [AuthController::class, 'logout'])->name('api.v1.logout');
     Route::get('me', [AuthController::class, 'me'])->name('api.v1.me');
 });


### PR DESCRIPTION
## Summary

Fix routes files after merge conflict:

- `routes/api.php`: Remove old `ApiRoute::version()` code, keep only comments
- `routes/api/v1.php`: Add missing `throttle:auth` and `throttle:authenticated` middleware

## Files fixed

**routes/api.php** - Now only contains documentation comments, routes are loaded from config

**routes/api/v1.php** - Now includes proper rate limiting:
- `throttle:auth` for public routes (5/min)
- `throttle:authenticated` for protected routes (120/min)